### PR TITLE
Bump hugo version

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.107.0'
+          hugo-version: '0.108.0'
       - name: Build
         run: hugo --gc --minify
       - name: Upload public directory

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build static artifacts using Hugo
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -29,7 +29,7 @@ jobs:
   deploy:
     name: Deploy to Netlify
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Download public directory
         uses: actions/download-artifact@v3

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,12 +3,12 @@
   command = "hugo --gc --minify"
 
 [build.environment]
-  HUGO_VERSION = "0.107.0"
+  HUGO_VERSION = "0.108.0"
 
 [context.deploy-preview]
   command = "hugo -b $DEPLOY_PRIME_URL --gc --minify"
   
 [context.production.environment]
-  HUGO_VERSION = "0.107.0"
+  HUGO_VERSION = "0.108.0"
   HUGO_ENV = "production"
   HUGO_ENABLEGITINFO = "true"


### PR DESCRIPTION
Bump hugo version to v0.108.0

While we're at it, also run workflows on `ubuntu-latest`.