### PR TITLE
fix: :bug: Fix banner link to privacy

### DIFF
--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -57,7 +57,7 @@
         functionality of this website.</span>
     <button id="cookie-notice-accept" class="btn btn-primary btn-sm">👌 OK</button>
     <button id="cookie-notice-deny" class="btn btn-primary btn-sm">🚫 No</button>
-    <button id="cookie-notice-more-info" class="btn btn-primary btn-sm"><a href="{{ .Permalink }}privacy"> ℹ️ More
+    <button id="cookie-notice-more-info" class="btn btn-primary btn-sm"><a href="/privacy"> ℹ️ More
             info</a></button>
 </div>
 <script>


### PR DESCRIPTION
Ensure we go to /privacy rather than <current-page>/privacy

Closes #18 